### PR TITLE
url for node norm has changed to nodenormalization-sri-dev.renci.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Answer Coalesce',
-    version='1.1.2',
+    version='1.1.3',
     author='Chris Bizon',
     author_email='bizon@renci.org',
     url='https://github.com/TranslatorIIPrototypes/AnswerCoalesce',

--- a/src/server.py
+++ b/src/server.py
@@ -174,7 +174,7 @@ def normalize(message):
     :param message:
     :return:
     """
-    url = 'https://nodenormalization-sri.renci.org/1.1/response'  # 'http://localhost:5000/response'
+    url = 'https://nodenormalization-sri-dev.renci.org/1.1/response'  # 'http://localhost:5000/response'
 
     normalized_message = post('Node Normalizer', url, message)
 

--- a/src/server.py
+++ b/src/server.py
@@ -27,7 +27,7 @@ logger = LoggingUtil.init_logging('answer_coalesce', level=logging.INFO, format=
 # declare the application and populate some details
 APP = FastAPI(
     title='Answer coalesce - A FastAPI UI/web service',
-    version='1.1.2'
+    version='1.1.3'
 )
 
 # declare the cross origin params
@@ -192,7 +192,7 @@ def construct_open_api_schema():
 
     open_api_schema = get_openapi(
         title='Answer Coalesce',
-        version='1.1.2',
+        version='1.1.3',
         routes=APP.routes
     )
 


### PR DESCRIPTION
like the title says