### PR TITLE
no qgraph update

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -52,7 +52,7 @@ class PropertyPatch:
         of those edges, as well as defining whether the edge points to the newnode (newnode_is = 'target')
         or away from it (newnode_is = 'source') """
         self.added_nodes.append( NewNode(newnode, newnodetype, edge_type, newnode_is, newnode_name) )
-    def apply(self,answers,question,graph,graph_index):
+    def apply(self,answers,question,graph,graph_index,patch_no):
         # Find the answers to combine.  It's not necessarily the answer_ids.  Those were the
         # answers that were originally in the opportunity, but we might have only found commonality
         # among a subset of them
@@ -65,7 +65,7 @@ class PropertyPatch:
         #If we're not adding a new node, extra_q_node = None, extra_q_edges = extra_k_edges =[]. No bindings to add
         #If we have an added node, the added node is always self.newnode
         # Also we will have an extra_q_node in that case, as well as one extra_q_edge, and 1 or more new k_edges
-        question,extra_q_nodes,extra_q_edges = self.update_qg(question)
+        #question,extra_q_nodes,extra_q_edges = self.update_qg(question)
         graph,all_extra_k_edges,graph_index = self.update_kg(graph,graph_index)
         #Start with some answer
         new_answer = deepcopy(comb_answers[0])
@@ -75,9 +75,8 @@ class PropertyPatch:
         #Add in any extra properties
         new_answer.add_properties(self.qg_id,self.new_props)
         #Add newnode-related bindings if necessary
-        for newnode,extra_q_node,extra_q_edge,extra_k_edges in \
-                zip(self.added_nodes,extra_q_nodes,extra_q_edges,all_extra_k_edges):
-            new_answer.add_bindings(extra_q_node, [newnode.newnode], extra_q_edge, extra_k_edges)
+        for node_no,(newnode,extra_k_edges) in enumerate(zip(self.added_nodes,all_extra_k_edges)):
+            new_answer.add_bindings([newnode.newnode], extra_k_edges, f'{patch_no}_{node_no}')
         return new_answer, question, graph, graph_index
     def isconsistent(self, possibleanswer):
         """
@@ -273,9 +272,9 @@ class Answer:
     def add_properties(self,qg_id,bps):
         """Update the property map of element qg_id with the properties in bps"""
         self.binding_properties[qg_id].update(bps)
-    def add_bindings(self,extra_q_node, newnode, extra_q_edge, extra_k_edges):
-        self.node_bindings[extra_q_node].update(newnode)
-        self.question_edge_bindings[extra_q_edge].update(extra_k_edges)
+    def add_bindings(self, newnode, extra_k_edges,counter):
+        self.node_bindings[f'_n_ac_{counter}'].update(newnode)
+        self.question_edge_bindings[f'_e_ac_{counter}'].update(extra_k_edges)
 
 
 

--- a/src/single_node_coalescer.py
+++ b/src/single_node_coalescer.py
@@ -58,7 +58,7 @@ def patch_answers(answerset, patches):
     for patch in patches:
         i += 1
         # print(f'{i} / {len(patches)}')
-        new_answer, qg, kg, kg_indexes = patch.apply(answers, qg, kg, kg_indexes)
+        new_answer, qg, kg, kg_indexes = patch.apply(answers, qg, kg, kg_indexes, i)
         if new_answer is not None:
             new_answers.append(new_answer.to_json())
     return new_answers, qg, kg

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -19,7 +19,7 @@ def test_basic():
     # get the location of the Translator specification file
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
 
-    testfilename = os.path.join(dir_path,jsondir,'D1_strider.json')
+    testfilename = os.path.join(dir_path,jsondir,'D.1_strider.json')
 
     with open(testfilename, 'r') as tf:
         answerset = json.load(tf)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -14,18 +14,18 @@ jsondir= 'InputJson_1.2'
 
 #TODO: This test requires use of the prod databases.  We should add pytest annotations distinguishing tests like this
 # so that the github actions can selectively run them
-def xtest_basic():
+def test_basic():
     """Bring back when properties are working again"""
     # get the location of the Translator specification file
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
 
-    testfilename = os.path.join(dir_path,jsondir,'sr_out_ac_hang.json')
+    testfilename = os.path.join(dir_path,jsondir,'D1_strider.json')
 
     with open(testfilename, 'r') as tf:
         answerset = json.load(tf)
 
     # make a good request
-    response = client.post('/coalesce/all', json=answerset)
+    response = client.post('/coalesce/graph', json=answerset)
 
     # was the request successful
     assert(response.status_code == 200)
@@ -36,6 +36,7 @@ def xtest_basic():
     # check the data
     ret = jret['message']
     assert(len(ret) == 3)
+    assert( len(ret['query_graph']['nodes']) < 6)
     assert( len(ret['results'])-len(answerset['message']['results']) > 0 )
 
 def xtest_wfa3():

--- a/tests/test_graph_coalescer.py
+++ b/tests/test_graph_coalescer.py
@@ -114,7 +114,8 @@ def test_graph_coalesce():
                 assert nb['id'] in kgnodes
                 #And each of these nodes should have a name
                 assert 'name' in newset['knowledge_graph']['nodes'][nb['id']]
-        assert extra_node
+        #We are no longer updating the qgraph.
+#        assert extra_node
         #make sure each new result has an extra edge
         nbs = r['edge_bindings']
         extra_edge = False
@@ -136,7 +137,8 @@ def test_graph_coalesce():
                     ac_prov = set( ['infores:aragorn', 'infores:automat-robokop'] )
                     assert len(values.intersection(ac_prov)) == 2
                     assert len(values) > len(ac_prov)
-        assert extra_edge
+        #We are no longer updating the qgraph
+#        assert extra_edge
 
 def test_graph_coalesce_strider():
     """Make sure that results are well formed."""

--- a/tests/test_node_coalescer.py
+++ b/tests/test_node_coalescer.py
@@ -253,12 +253,9 @@ def test_apply_property_patches_add_new_node_that_isnt_new():
     #This is the new line:
     patch.add_extra_node("E",'biolink:NamedThing','biolink:is_a',newnode_is='target',newnode_name='newname')
     new_answers,updated_qg,updated_kg = snc.patch_answers(answerset,[patch])
-    #Did we patch the question correctly?
-    assert len(updated_qg['nodes']) == 5 #started as 4
-    assert len(updated_qg['edges']) == 4 #started as 3
-    #n2 should now be a set in the question
-    vnode = updated_qg['nodes']['n2']
-    assert vnode['is_set']
+    #Did we patch the question correctly? We're not supposed to update it
+    assert len(updated_qg['nodes']) == 4 #started as 4
+    assert len(updated_qg['edges']) == 3 #started as 3
     #Don't want to break any of the stuff that was already working...
     assert len(new_answers) == 1
     na = new_answers[0]
@@ -273,7 +270,7 @@ def test_apply_property_patches_add_new_node_that_isnt_new():
     #take advantage of node_bindings being a list.  it's a little hinky
     found_extra = False
     for nb_id, nbs in na['node_bindings'].items():
-        if nb_id.startswith('extra'):
+        if nb_id.startswith('_n_ac'):
             found_extra = True
             assert len(nbs) == 1
             assert nbs[0]['id'] == 'E'
@@ -304,7 +301,7 @@ def test_apply_property_patches_add_new_node_that_isnt_new():
     assert found
     found_extra_edges = False
     for edge_id, edge_binding in na['edge_bindings'].items():
-        if edge_id.startswith('extra'):
+        if edge_id.startswith('_e_ac'):
             found_extra_edges = True
             assert len(edge_binding)== 1 #is it pointing to the new kg_id edge?
             assert edge_binding[0]['id'] == eid #is it pointing to the new
@@ -358,12 +355,9 @@ def test_apply_property_patches_add_two_new_nodes():
     patch.add_extra_node("Q",'biolink:NamedThing','biolink:part_of',newnode_is='target',newnode_name='targ')
     patch.add_extra_node("R",'biolink:NamedThing','biolink:interacts_with',newnode_is='source',newnode_name='surc')
     new_answers,updated_qg,updated_kg = snc.patch_answers(answerset,[patch])
-    #Did we patch the question correctly?
-    assert len(updated_qg['nodes']) == 6 #started as 4
-    assert len(updated_qg['edges']) == 5 #started as 3
-    #n2 should now be a set in the question
-    vnode = updated_qg['nodes']['n2']
-    assert vnode['is_set']
+    #Did we (not) patch the question correctly?  We are not updating qgraph any more
+    assert len(updated_qg['nodes']) == 4 #started as 4
+    assert len(updated_qg['edges']) == 3 #started as 3
     #Don't want to break any of the stuff that was already working...
     assert len(new_answers) == 1
     na = new_answers[0]
@@ -379,7 +373,7 @@ def test_apply_property_patches_add_two_new_nodes():
     found_R = False
     found_Q = False
     for nb_id, nbs in na['node_bindings'].items():
-        if nb_id.startswith('extra'):
+        if nb_id.startswith('_n_ac'):
             assert len(nbs) == 1
             if nbs[0]['id'] == 'R':
                 found_R = True


### PR DESCRIPTION
Don't update the qgraph, so we don't end up with a zillion nodes for no reason.

Instead, allow bindings to not point to anything in the qgraph.