### PR TITLE
Fix MCQ qualifier constraint parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+
       - name: Install dependencies
         run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          .venv/bin/pip install -r requirements-test.txt
 
 
 #      - name: Start Redis
@@ -47,8 +51,8 @@ jobs:
 
       - name: Load redis
         run: |
-          python src/graph_coalescence/load_redis.py test
+          .venv/bin/python src/graph_coalescence/load_redis.py test
 
       - name: Run the tests
         run: |
-          pytest -m "not nongithub" tests/
+          .venv/bin/pytest -m "not nongithub" tests/

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Query edges also support `qualifier_constraints` (e.g. `species_context_qualifie
 ### Local
 
 ```bash
+conda create -n answercoalesce python=3.12
+conda activate answercoalesce
 pip install -r requirements.txt
 uvicorn src.server:APP --host 0.0.0.0 --port 6380
 ```
@@ -116,6 +118,10 @@ The AC Redis database is built on Hatteras via a Slurm pipeline. See [`src/ac_pi
 ## Testing
 
 ```bash
+conda create -n answercoalesce-test python=3.12
+conda activate answercoalesce-test
+pip install -r requirements-test.txt
+
 # Unit tests (no Redis required)
 pytest tests/test_inputs.py tests/test_redis_build.py
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest==8.2.2
+pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pyyaml~=6.0.1
 argparse~=1.4.0
 setuptools~=71.0.4
 requests~=2.32.3
-pytest==8.2.2
 scipy~=1.14.0
 sparqlwrapper~=2.0.0
 redis~=5.0.7
@@ -19,4 +18,3 @@ uvicorn==0.30.3
 reasoner-pydantic~=5.0.6
 jsonlines
 orjson
-pytest-asyncio

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""AnswerCoalesce source package."""

--- a/src/components.py
+++ b/src/components.py
@@ -5,6 +5,62 @@ import json
 import orjson
 
 
+def _normalized_qualifier_type(qualifier_type: str) -> str:
+    if qualifier_type.startswith("biolink:"):
+        return qualifier_type
+    return f"biolink:{qualifier_type}"
+
+
+def _qedge_qualifier_key(qualifier_type: str) -> str:
+    return qualifier_type.split(":")[-1] if ":" in qualifier_type else qualifier_type
+
+
+def get_qedge_qualifiers(qedge: dict) -> list[dict]:
+    """Extract the first qualifier set from supported QEdge qualifier shapes."""
+    qualifier_constraints = qedge.get("qualifier_constraints", [])
+    if qualifier_constraints:
+        qualifier_set = qualifier_constraints[0].get("qualifier_set", [])
+        return [
+            {
+                "qualifier_type_id": _normalized_qualifier_type(q["qualifier_type_id"]),
+                "qualifier_value": q["qualifier_value"],
+            }
+            for q in qualifier_set
+            if "qualifier_type_id" in q and "qualifier_value" in q
+        ]
+
+    constraints_qualifiers = qedge.get("constraints", {}).get("qualifiers", [])
+    if not constraints_qualifiers:
+        return []
+
+    first_qualifier_set = constraints_qualifiers[0]
+    if "qualifier_type_id" in first_qualifier_set and "qualifier_value" in first_qualifier_set:
+        return [
+            {
+                "qualifier_type_id": _normalized_qualifier_type(q["qualifier_type_id"]),
+                "qualifier_value": q["qualifier_value"],
+            }
+            for q in constraints_qualifiers
+            if "qualifier_type_id" in q and "qualifier_value" in q
+        ]
+
+    return [
+        {
+            "qualifier_type_id": _normalized_qualifier_type(qualifier_type),
+            "qualifier_value": qualifier_value,
+        }
+        for qualifier_type, qualifier_value in first_qualifier_set.items()
+    ]
+
+
+def get_qedge_predicate_parts(qedge: dict) -> dict:
+    parts = {"predicate": qedge.get("predicates", ["biolink:related_to"])[0]}
+    for qualifier in get_qedge_qualifiers(qedge):
+        key = _qedge_qualifier_key(qualifier["qualifier_type_id"])
+        parts[key] = qualifier["qualifier_value"]
+    return parts
+
+
 ###
 # These classes are used to extract the meaning from the TRAPI MCQ query into a more usable form
 ###
@@ -37,16 +93,8 @@ class MCQEdge:
                 self.group_is_subject = False
             self.qedge_id = qedge_id
             self.predicate_only = qedge.get("predicates", ["biolink:related_to"])[0]
-            self.predicate = {"predicate": self.predicate_only}
-            self.qualifiers = []
-            qualifier_constraints = qedge.get("qualifier_constraints", [])
-            if len(qualifier_constraints) > 0:
-                qc = qualifier_constraints[0]
-                self.qualifiers = qc.get("qualifier_set", [])
-                for q in self.qualifiers:
-                    qt = q["qualifier_type_id"]
-                    key = qt.split(":")[-1] if ":" in qt else qt
-                    self.predicate[key] = q["qualifier_value"]
+            self.qualifiers = get_qedge_qualifiers(qedge)
+            self.predicate = get_qedge_predicate_parts(qedge)
 
 
 class MCQDefinition:
@@ -170,14 +218,7 @@ class QueryParams:
     @staticmethod
     def _build_predicate_parts(qedge: dict) -> str:
         """Build predicate JSON string with all qualifiers from the query edge."""
-        parts = {"predicate": qedge.get("predicates", ["biolink:related_to"])[0]}
-
-        for qc in qedge.get("qualifier_constraints", []):
-            for q in qc.get("qualifier_set", []):
-                qualifier_type = q.get("qualifier_type_id", "")
-                key = qualifier_type.split(":")[-1] if ":" in qualifier_type else qualifier_type
-                parts[key] = q.get("qualifier_value")
-
+        parts = get_qedge_predicate_parts(qedge)
         return json.dumps(parts, sort_keys=True)
 
 

--- a/tests/test_trapi_generation.py
+++ b/tests/test_trapi_generation.py
@@ -60,6 +60,57 @@ async def test_get_mcq_components():
 
 
 @pytest.mark.asyncio
+async def test_multi_curie_query_applies_constraints_qualifiers_to_graph_filter(monkeypatch):
+    in_message = {
+        "message": {
+            "query_graph": {
+                "nodes": {
+                    "input": {
+                        "set_interpretation": "MANY",
+                        "member_ids": ["CHEBI:167574", "CHEBI:71193"],
+                        "categories": ["biolink:ChemicalEntity"],
+                        "ids": ["uuid:1"],
+                    },
+                    "output": {"categories": ["biolink:Gene"]},
+                },
+                "edges": {
+                    "edge_0": {
+                        "subject": "input",
+                        "object": "output",
+                        "predicates": ["biolink:affects"],
+                        "constraints": {
+                            "qualifiers": [
+                                {
+                                    "biolink:object_aspect_qualifier": "activity",
+                                    "biolink:object_direction_qualifier": "increased",
+                                }
+                            ]
+                        },
+                    }
+                },
+            }
+        }
+    }
+    observed_kwargs = {}
+
+    async def fake_coalesce_by_graph(*args, **kwargs):
+        observed_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(snc, "coalesce_by_graph", fake_coalesce_by_graph)
+
+    await snc.multi_curie_query(in_message, {})
+
+    assert observed_kwargs["predicate_constraints"] == [
+        {
+            "predicate": "biolink:affects",
+            "object_aspect_qualifier": "activity",
+            "object_direction_qualifier": "increased",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_or_find_member_of_edges_existing_edges():
     """In this test there is already one member_of edge (for id1) But not for id2"""
     message = {


### PR DESCRIPTION
## Summary
- Parse TRAPI constraints.qualifiers in addition to qualifier_constraints.
- Reuse one QEdge qualifier parser for MCQ and single-curie query paths so qualifier filters are constructed consistently.
- Add regression coverage for issue #141 qualified biolink:affects MCQ queries.
- Make pytest import this repo's local src package instead of any globally injected src package.
- Split test-only dependencies into requirements-test.txt and document conda/venv-based installs.

## Why
- Qualified set-input queries were preserving qualifier constraints in the echoed query graph but passing only the bare predicate into graph coalescence, so missing, broader, or opposite qualifier rows could pass through.
- This repo uses src as its top-level import package, but src lacked an __init__.py and pytest had no local pythonpath config. On a machine with another installed src package, normal pytest could import the wrong repo.
- Deployment installs requirements.txt, so pytest dependencies should not be runtime requirements. Local installs and CI now use an explicit conda or virtual environment rather than system Python.

## Test
- python -m venv /private/tmp/ac-test-env-answercoalesce-141
- /private/tmp/ac-test-env-answercoalesce-141/bin/python -m pip install -r requirements-test.txt
- /private/tmp/ac-test-env-answercoalesce-141/bin/python -m pytest tests/test_trapi_generation.py

Fixes #141